### PR TITLE
[Fix] Fixed behavior of ft_strnstr as original strnstr #2

### DIFF
--- a/ft_strnstr.c
+++ b/ft_strnstr.c
@@ -6,7 +6,7 @@
 /*   By: tashimiz <tashimiz@student.42tokyo.jp      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/27 17:00:24 by tashimiz          #+#    #+#             */
-/*   Updated: 2022/01/27 17:00:25 by tashimiz         ###   ########.fr       */
+/*   Updated: 2022/01/29 16:25:55 by tashimiz         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,6 +21,8 @@ char	*ft_strnstr(const char *haystack, const char *needle, size_t len)
 	len_ndl = ft_strlen(needle);
 	if (len_ndl == 0)
 		return ((char *)haystack);
+	if (len == 0)
+		return (NULL);
 	p_hs = (const char *)haystack;
 	while (*p_hs != '\0' && len >= len_ndl)
 	{


### PR DESCRIPTION
When [dst == NULL] && [src != NULL] && [size == 0], my previous code
performs SEGV. However, the original did not perform SEGV.
I fixed the behavior of my strnstr in that condition as same as the
original strnstr.