### PR TITLE
[Fix] Fixed the logic of atoi over/underflow detection. #3

### DIFF
--- a/ft_atoi.c
+++ b/ft_atoi.c
@@ -6,7 +6,7 @@
 /*   By: tashimiz <tashimiz@student.42tokyo.jp      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/01/27 16:53:38 by tashimiz          #+#    #+#             */
-/*   Updated: 2022/01/27 16:53:45 by tashimiz         ###   ########.fr       */
+/*   Updated: 2022/01/30 10:27:22 by tashimiz         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,22 +26,11 @@ static int	ft_isspace(int c)
 		return (0);
 }
 
-// overflow -> 1, underflow -> 2
-static int	is_overflow(const char *str, int num, int sign)
-{
-	if (sign == -1 && num != 0 && LONG_MIN / num > sign)
-		return (2);
-	else if (sign == 1 && LONG_MAX - num * 10 < (*str - '0'))
-		return (1);
-	else
-		return (0);
-}
-
 // convert ASCII string to integer
 int	ft_atoi(const char *str)
 {
-	int	num;
-	int	sign;
+	long	num;
+	int		sign;
 
 	num = 0;
 	sign = 1;
@@ -53,12 +42,15 @@ int	ft_atoi(const char *str)
 		str++;
 	while (ft_isdigit(*str))
 	{
-		if (is_overflow(str, num, sign) == 1)
-			return ((int)LONG_MAX);
-		else if (is_overflow(str, num, sign) == 2)
-			return ((int)LONG_MIN);
+		if ((num * 10 + (*str - '0')) / 10 != num)
+		{
+			if (sign == -1)
+				return (0);
+			else
+				return (-1);
+		}
 		num = num * 10 + (*str - '0');
 		str++;
 	}
-	return (num * sign);
+	return ((int)num * sign);
 }


### PR DESCRIPTION
I was supposed to detect overflow and underflow detection with comparing
LONG_MAX or LONG_MIN value with currently comverted numbers.
However this logic did not work boundary value +5 ~ -5.

I fixed the detection logic.
lvalue-> be supposed to convert and divide by 10
rvalue-> original converted number

[detection logic(overflow)]
e.g)
str = "9223372036854775808" ->overflow

conversion = 92233720368547758 * 10 + (*str - '0') = -9223372036854775808
lvalue = ((922337203685477580 * 10) + (*str - '0')) / 10 = -922337203685477580
rvalue = 922337203685477580

since lvalue != rvalue, this conversion is going to be overflow.
and this detection logic also work for underflow detection.